### PR TITLE
Fix SIGSEGV in vkCreateInstance due to improper object lifetime management

### DIFF
--- a/Engine/gapi/vulkan/vulkanapi_impl.cpp
+++ b/Engine/gapi/vulkan/vulkanapi_impl.cpp
@@ -52,7 +52,7 @@ VulkanInstance::VulkanInstance(bool validation)
   createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
   createInfo.pApplicationInfo = &appInfo;
 
-  auto extensions = std::initializer_list<const char*>{
+  const std::initializer_list<const char*>& extensions = std::initializer_list<const char*>{
     VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
     VK_KHR_SURFACE_EXTENSION_NAME,
     SURFACE_EXTENSION_NAME,


### PR DESCRIPTION
On Linux when compiling with Clang the `extensions` variable is optimized away causing `createInfo.ppEnabledExtensionNames` to contain a pointer to invalid data. This causes the Vulkan backend to crash with a `SIGSEGV`. Just making `extensions` a const-reference fixes this issue.