### PR TITLE
Window focus for X11

### DIFF
--- a/Engine/system/api/x11api.cpp
+++ b/Engine/system/api/x11api.cpp
@@ -191,7 +191,8 @@ SystemApi::Window *X11Api::implCreateWindow(Tempest::Window *owner, uint32_t w, 
   swa.colormap   = cmap;
   swa.event_mask = PointerMotionMask | ExposureMask |
                    ButtonPressMask | ButtonReleaseMask |
-                   KeyPressMask | KeyReleaseMask;
+                   KeyPressMask | KeyReleaseMask |
+                   FocusChangeMask;
 
   HWND win = XCreateWindow( dpy, root, 0, 0, w, h,
                             0, vi->depth, InputOutput, vi->visual,
@@ -497,6 +498,16 @@ void X11Api::implProcessEvents(SystemApi::AppCallBack &cb) {
           SystemApi::dispatchKeyUp  (cb,e,scan);
         break;
         }
+      case FocusIn: {
+        FocusEvent e(true, Event::UnknownReason);
+        SystemApi::dispatchFocus(cb, e);
+        break;
+      }
+      case FocusOut: {
+        FocusEvent e(false, Event::UnknownReason);
+        SystemApi::dispatchFocus(cb, e);
+        break;
+      }
       }
 
     std::this_thread::yield();

--- a/Engine/system/api/x11api.cpp
+++ b/Engine/system/api/x11api.cpp
@@ -502,12 +502,12 @@ void X11Api::implProcessEvents(SystemApi::AppCallBack &cb) {
         FocusEvent e(true, Event::UnknownReason);
         SystemApi::dispatchFocus(cb, e);
         break;
-      }
+        }
       case FocusOut: {
         FocusEvent e(false, Event::UnknownReason);
         SystemApi::dispatchFocus(cb, e);
         break;
-      }
+        }
       }
 
     std::this_thread::yield();

--- a/Engine/system/eventdispatcher.cpp
+++ b/Engine/system/eventdispatcher.cpp
@@ -309,7 +309,7 @@ std::shared_ptr<Widget::Ref> EventDispatcher::implDispatch(Widget& root, FocusEv
   while(w->astate.focus!=nullptr) {
     w = w->astate.focus;
     }
-  if(!event.in) {
+  if(w->wstate.focus) {
     auto ptr = w->selfReference();
     w->setFocus(false);
     return ptr;

--- a/Engine/system/eventdispatcher.cpp
+++ b/Engine/system/eventdispatcher.cpp
@@ -309,7 +309,7 @@ std::shared_ptr<Widget::Ref> EventDispatcher::implDispatch(Widget& root, FocusEv
   while(w->astate.focus!=nullptr) {
     w = w->astate.focus;
     }
-  if(w->wstate.focus) {
+  if(!event.in) {
     auto ptr = w->selfReference();
     w->setFocus(false);
     return ptr;

--- a/Engine/system/eventdispatcher.cpp
+++ b/Engine/system/eventdispatcher.cpp
@@ -206,10 +206,9 @@ void EventDispatcher::dispatchFocus(Widget& wnd, FocusEvent& e) {
     return;
     }
 
-  if (!focusLast.expired())
+  if(!focusLast.expired())
     return;
 
-  focusLast.reset();
   for(auto i:overlays) {
     if(!i->bind(wnd))
       continue;

--- a/Engine/system/eventdispatcher.cpp
+++ b/Engine/system/eventdispatcher.cpp
@@ -206,6 +206,9 @@ void EventDispatcher::dispatchFocus(Widget& wnd, FocusEvent& e) {
     return;
     }
 
+  if (!wnd.hasFocus() || !focusLast.expired())
+    return;
+
   focusLast.reset();
   for(auto i:overlays) {
     if(!i->bind(wnd))

--- a/Engine/system/eventdispatcher.cpp
+++ b/Engine/system/eventdispatcher.cpp
@@ -206,7 +206,7 @@ void EventDispatcher::dispatchFocus(Widget& wnd, FocusEvent& e) {
     return;
     }
 
-  if (!wnd.hasFocus() || !focusLast.expired())
+  if (!focusLast.expired())
     return;
 
   focusLast.reset();


### PR DESCRIPTION
As discussed in #42 the implementation for X11. Meanwhile I also noticed a bug in the focus handling. X11 sends FocusOut twice, which caused 
https://github.com/Try/Tempest/blob/30567a3f10ae13c758f71adb3628e82479c5633c/Engine/system/eventdispatcher.cpp#L312
to be false the second time and setting `focusLast = nullptr` and therefore FocusIn did not restore focus because this code is not executed https://github.com/Try/Tempest/blob/30567a3f10ae13c758f71adb3628e82479c5633c/Engine/system/eventdispatcher.cpp#L202
I added a commit to fix this.