### PR TITLE
v1 Audio default device changed notification - attempt to resolve #61

### DIFF
--- a/Engine/sound/sounddevice.cpp
+++ b/Engine/sound/sounddevice.cpp
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <mutex>
+#include <thread>
 
 using namespace Tempest;
 

--- a/Engine/system/api/windowsapi.h
+++ b/Engine/system/api/windowsapi.h
@@ -4,9 +4,12 @@
 
 namespace Tempest {
 
+class AudioDeviceChangedListener;
+
 class WindowsApi final : SystemApi {
   private:
     WindowsApi();
+    ~WindowsApi();
 
     Window*  implCreateWindow(Tempest::Window* owner, uint32_t width, uint32_t height, ShowMode sm);
     Window*  implCreateWindow(Tempest::Window *owner, uint32_t width, uint32_t height) override;
@@ -29,6 +32,8 @@ class WindowsApi final : SystemApi {
 
     static long long windowProc(void* hWnd, uint32_t msg, const unsigned long long wParam, const long long lParam);
     static void handleKeyEvent(Tempest::Window* cb, uint32_t msg, const unsigned long long wParam, const long long lParam);
+
+    std::unique_ptr<AudioDeviceChangedListener> audioDeviceListener;
 
   friend class SystemApi;
   };

--- a/Engine/system/systemapi.cpp
+++ b/Engine/system/systemapi.cpp
@@ -30,7 +30,7 @@ SystemApi::SystemApi() {
   }
 
 void SystemApi::implSetWindowTitle(Window *w, const char *utf8) {
-  // TODO
+  // TO
   }
 
 void SystemApi::setupKeyTranslate(const TranslateKeyPair k[], uint16_t funcCount ) {
@@ -64,6 +64,16 @@ void SystemApi::addOverlay(UiOverlay* ui) {
 
 void SystemApi::takeOverlay(UiOverlay* ui) {
   dispatcher.takeOverlay(ui);
+  }
+
+void SystemApi::setAudioDeviceChangedCallback( std::function<void()> callback ) {
+  audioDeviceChangedCallback = callback;
+  }
+
+void SystemApi::callAudioDeviceChangedCallback() {
+  if(audioDeviceChangedCallback) {
+    audioDeviceChangedCallback();
+    }
   }
 
 uint16_t SystemApi::translateKey(uint64_t scancode) {
@@ -205,4 +215,3 @@ void SystemApi::setCursorPosition(SystemApi::Window *w, int x, int y) {
 void SystemApi::showCursor(SystemApi::Window *w, CursorShape show) {
   return inst().implShowCursor(w,show);
   }
-

--- a/Engine/system/systemapi.h
+++ b/Engine/system/systemapi.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <cstdint>
+#include <functional>
 
 namespace Tempest {
 
@@ -58,6 +59,9 @@ class SystemApi {
     static void     addOverlay (UiOverlay* ui);
     static void     takeOverlay(UiOverlay* ui);
 
+    static void     setAudioDeviceChangedCallback( std::function<void()> callback );
+    static void     callAudioDeviceChangedCallback( );
+
   protected:
     struct AppCallBack {
       virtual ~AppCallBack()=default;
@@ -103,6 +107,8 @@ class SystemApi {
     static void      dispatchFocus     (Tempest::Window& cb, FocusEvent& e);
 
     static SystemApi& inst();
+
+    static inline std::function<void()> audioDeviceChangedCallback = []{};
 
   private:
     static bool       isRunning();


### PR DESCRIPTION
Implements the AudioDeviceChangedListener class for the win api. When the user now changes the default audio endpoint (headphones to speakers) the game will also switch to that desired output.