### PR TITLE
vswapchain: don't assert on SUBOPTIMAL swapchains

### DIFF
--- a/Engine/gapi/vulkan/vswapchain.cpp
+++ b/Engine/gapi/vulkan/vswapchain.cpp
@@ -353,7 +353,7 @@ VkResult VSwapchain::implAcquireNextImage() {
     return code;
     }
 
-  if(code!=VK_SUCCESS)
+  if(code!=VK_SUCCESS && code!=VK_SUBOPTIMAL_KHR)
     vkAssert(code);
 
   imgIndex   = id;


### PR DESCRIPTION
The code deals with them just fine, but handling is done after the function returns.

Surprising no one has ran into this yet. Maybe its because the Windows swapchain never uses SUBOPTIMAL IIRC, but on Linux, you get suboptimal on every resize.