### PR TITLE
Prefer working-directory files in iOS RFile

### DIFF
--- a/Engine/io/rfile.mm
+++ b/Engine/io/rfile.mm
@@ -5,7 +5,9 @@
 #include <Tempest/TextCodec>
 #include <Tempest/Except>
 
-#import  <UIKit/UIKit.h>
+#include <cstdio>
+
+#import <Foundation/Foundation.h>
 
 using namespace Tempest;
 
@@ -16,7 +18,12 @@ void* RFile::implOpen(const char *cstr) {
       throw std::system_error(Tempest::SystemErrc::UnableToOpenFile);
     return ret;
     }
-  
+
+  // Relative paths may refer to user-provided files in the process working
+  // directory. Packaged application resources remain the fallback.
+  if(void* ret = fopen(cstr,"rb"))
+    return ret;
+
   @autoreleasepool {
     NSString *dir = [[NSBundle mainBundle] resourcePath];
     std::string full = [dir UTF8String];


### PR DESCRIPTION
Relative paths opened through `RFile` on iOS are currently resolved only against the application bundle.

This change checks the process working directory first and uses the application bundle as a fallback. Absolute-path behavior remains unchanged, and the change is limited to iOS.

Testing:
- TempestTests on macOS: 174 passed
- iPhoneOS arm64 Release build
- iPhone Simulator arm64 Release build