### PR TITLE
Fix Painter triangle state initialization

### DIFF
--- a/Engine/2d/painter.cpp
+++ b/Engine/2d/painter.cpp
@@ -85,6 +85,11 @@ void Painter::implSetColor(float r, float g, float b, float a) {
 void Painter::drawTriangle(int x0, int y0, float u0, float v0,
                            int x1, int y1, float u1, float v1,
                            int x2, int y2, float u2, float v2) {
+  if(state!=StBrush) {
+    dev.setTopology(Triangles);
+    state=StBrush;
+    implBrush(s.br);
+    }
   FPoint trigBuf[4+4+4+4];
   implDrawTrig( float(x0), float(y0), s.dU+u0*s.invW,s.dV+v0*s.invH,
                 float(x1), float(y1), s.dU+u1*s.invW,s.dV+v1*s.invH,
@@ -95,6 +100,11 @@ void Painter::drawTriangle(int x0, int y0, float u0, float v0,
 void Painter::drawTriangle(float x0, float y0, float u0, float v0,
                            float x1, float y1, float u1, float v1,
                            float x2, float y2, float u2, float v2) {
+  if(state!=StBrush) {
+    dev.setTopology(Triangles);
+    state=StBrush;
+    implBrush(s.br);
+    }
   FPoint trigBuf[4+4+4+4];
   implDrawTrig( x0, y0, s.dU+u0*s.invW,s.dV+v0*s.invH,
                 x1, y1, s.dU+u1*s.invW,s.dV+v1*s.invH,


### PR DESCRIPTION
`Painter::drawTriangle()` currently emits triangle vertices without ensuring that the brush pipeline and triangle topology are active. This makes direct triangle drawing depend on the preceding Painter operation.

This change initializes the brush state in both `drawTriangle()` overloads, consistently with the other brush drawing paths.

Testing:
- TempestTests on macOS: 174 passed
- iPhoneOS arm64 Release build
- iPhone Simulator arm64 Release build