### PR TITLE
Use shared storage for host-visible Metal resources on iOS

### DIFF
--- a/Engine/gapi/metal/mtaccelerationstructure.cpp
+++ b/Engine/gapi/metal/mtaccelerationstructure.cpp
@@ -100,7 +100,7 @@ MtTopAccelerationStructure::MtTopAccelerationStructure(MtDevice& dx, const RtIns
   :owner(dx) {
   auto pool = NsPtr<NS::AutoreleasePool>::init();
   instances = NsPtr<MTL::Buffer>(dx.impl->newBuffer(sizeof(MTL::AccelerationStructureUserIDInstanceDescriptor)*asSize,
-                                                    MTL::ResourceStorageModeManaged));
+                                                    hostVisibleResourceOptions(*dx.impl)));
   if(instances==nullptr)
     throw std::system_error(GraphicsErrc::OutOfVideoMemory);
 
@@ -128,7 +128,8 @@ MtTopAccelerationStructure::MtTopAccelerationStructure(MtDevice& dx, const RtIns
       blas.push_back(ax->impl.get());
       }
     }
-  instances->didModifyRange(NS::Range(0,instances->length()));
+  if(instances->storageMode()==MTL::StorageModeManaged)
+    instances->didModifyRange(NS::Range(0,instances->length()));
 
   auto asArray = NsPtr<NS::Array>(NS::Array::array(reinterpret_cast<NS::Object**>(blas.data()), blas.size()));
   auto desc    = NsPtr<MTL::InstanceAccelerationStructureDescriptor>::init();
@@ -196,4 +197,3 @@ void MtTopAccelerationStructure::implUseResource(MTL::RenderCommandEncoder& cmd,
   }
 
 #endif
-

--- a/Engine/gapi/metal/mtdevice.h
+++ b/Engine/gapi/metal/mtdevice.h
@@ -19,6 +19,22 @@ class MTLDevice;
 namespace Tempest {
 namespace Detail {
 
+inline MTL::StorageMode hostVisibleStorageMode(MTL::Device& dev) {
+#ifdef __IOS__
+  // Managed storage is unavailable on iOS. The Simulator can still report
+  // hasUnifiedMemory()==false, so platform support is authoritative here.
+  (void)dev;
+  return MTL::StorageModeShared;
+#else
+  return dev.hasUnifiedMemory() ? MTL::StorageModeShared : MTL::StorageModeManaged;
+#endif
+  }
+
+inline MTL::ResourceOptions hostVisibleResourceOptions(MTL::Device& dev) {
+  return hostVisibleStorageMode(dev)==MTL::StorageModeShared
+           ? MTL::ResourceStorageModeShared
+           : MTL::ResourceStorageModeManaged;
+  }
 inline MTL::PixelFormat nativeFormat(TextureFormat frm) {
   switch(frm) {
     case Undefined:

--- a/Engine/gapi/metal/mttexture.cpp
+++ b/Engine/gapi/metal/mttexture.cpp
@@ -45,7 +45,7 @@ MtTexture::MtTexture(MtDevice& d, const uint32_t w, const uint32_t h, const uint
 MtTexture::MtTexture(MtDevice& dev, const Pixmap& pm, uint32_t mipCnt, TextureFormat frm)
   :dev(dev), mipCnt(mipCnt) {
   const uint32_t         smip  = (isCompressedFormat(frm) ? mipCnt : 1);
-  const MTL::StorageMode smode = dev.impl->hasUnifiedMemory() ? MTL::StorageModeShared : MTL::StorageModeManaged;
+  const MTL::StorageMode smode = hostVisibleStorageMode(*dev.impl);
 
   NsPtr<MTL::Texture> stage = alloc(frm,pm.w(),pm.h(),0,smip,smode,MTL::TextureUsageShaderRead);
   impl = alloc(frm,pm.w(),pm.h(),0,mipCnt,MTL::StorageModePrivate,MTL::TextureUsageShaderRead);
@@ -152,7 +152,7 @@ void MtTexture::readPixels(Pixmap& out, TextureFormat frm, const uint32_t w, con
     throw std::runtime_error("not implemented");
   out = Pixmap(w,h,frm);
 
-  const MTL::StorageMode opt = dev.impl->hasUnifiedMemory() ? MTL::StorageModeShared : MTL::StorageModeManaged;
+  const MTL::StorageMode opt = hostVisibleStorageMode(*dev.impl);
 
   NsPtr<MTL::Texture> stage = alloc(frm,w,h,0,1,opt,MTL::TextureUsageShaderRead);
   auto pool = NsPtr<NS::AutoreleasePool>::init();

--- a/Engine/gapi/metalapi.cpp
+++ b/Engine/gapi/metalapi.cpp
@@ -108,18 +108,12 @@ AbstractGraphicsApi::PBuffer MetalApi::createBuffer(AbstractGraphicsApi::Device 
       opt |= MTL::ResourceStorageModePrivate;
       break;
     case BufferHeap::Upload: {
-      if(dx.impl->hasUnifiedMemory()) {
-        // Shared resources are only available on systems with integrated graphics,
-        // such as Apple silicon and integrated GPUs on Intel-based Mac computers
-        opt |= MTL::ResourceStorageModeShared;
-        } else {
-        opt |= MTL::ResourceStorageModeManaged;
-        }
+      opt |= hostVisibleResourceOptions(*dx.impl);
       opt |= MTL::ResourceCPUCacheModeWriteCombined;
       break;
       }
     case BufferHeap::Readback:
-      opt |= MTL::ResourceStorageModeManaged;
+      opt |= hostVisibleResourceOptions(*dx.impl);
       opt |= MTL::ResourceCPUCacheModeDefaultCache;
       break;
     }


### PR DESCRIPTION
Metal managed storage is unavailable on iOS, while the Simulator may still report `hasUnifiedMemory()` as false.

This change centralizes host-visible storage selection. iOS always uses shared storage, while macOS keeps the existing shared-or-managed behavior. Upload, readback, texture-staging and acceleration-structure resources use the same policy.

Testing:
- TempestTests on macOS: 174 passed
- iPhoneOS arm64 Release build
- iPhone Simulator arm64 Release build