### PR TITLE
Fix CTest registration for TempestTests

### DIFF
--- a/Tests/tests/CMakeLists.txt
+++ b/Tests/tests/CMakeLists.txt
@@ -9,7 +9,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/testsuite)
 # Setup testing
 enable_testing()
 add_executable(${PROJECT_NAME})
-add_test(${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+set_tests_properties(${PROJECT_NAME} PROPERTIES
+  WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
 target_include_directories(${PROJECT_NAME} PRIVATE .)
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/../../Engine/include")


### PR DESCRIPTION
The current `add_test` call mixes the legacy signature with the `COMMAND` keyword. As a result, CTest treats `COMMAND` as the executable name and fails with `TempestTests: command not found`.

Use the `NAME ... COMMAND ...` signature so CMake resolves the test target to its configuration-specific executable path. Run it from the existing runtime output directory, where the test assets and generated shaders are available.

Validation:
- reproduced the failure on current master
- CTest passes all 174 tests with Unix Makefiles
- CTest passes all 174 tests with Ninja Multi-Config
- fork CI passes on MSVC, MinGW, Ubuntu, and macOS

The current GitHub Actions workflow invokes `TempestTests` directly, so this change affects CTest registration rather than the existing CI command.