### PR TITLE
Fix iOS autorelease pool lifetime across fiber yields

### DIFF
--- a/Engine/system/api/iosapi.mm
+++ b/Engine/system/api/iosapi.mm
@@ -452,7 +452,10 @@ void iOSApi::implProcessEvents(AppCallBack& cb) {
     return;
     }
   
-  @autoreleasepool {
+  // UIKit already owns an autorelease pool around each event-loop iteration.
+  // A nested processEvents() can let UIKit drain that outer pool before this
+  // fiber frame resumes, so do not push a pool whose lifetime spans callbacks.
+  {
     auto& wnd   = *mainWindow->owner;
     auto  eType = mainWindow->curentEvent;
     mainWindow->curentEvent = Event::Type::NoEvent;


### PR DESCRIPTION
The iOS backend currently keeps a local autorelease pool alive while it dispatches an engine event. An event callback can call `processEvents()` again, yield to UIKit and let the surrounding run-loop pool drain before the engine fiber resumes. Popping the local pool after that can trigger an autorelease-pool `badPop` crash.

Remove only the pool that spans event dispatch. UIKit still provides the autorelease pool for each event-loop iteration, and the short pool used by the render callback is unchanged.

Validation:
- reproduced the pool corruption with a focused Objective-C++ harness
- 175/175 Tempest tests pass on macOS
- Release builds pass for iPhoneOS arm64 and iPhone Simulator arm64 at iOS 15.0
- an integrated probe on an iPhone 15 Pro Max completes nested `processEvents()` without a crash