### PR TITLE
Handle cancelled touches on iOS

### DIFF
--- a/Engine/system/api/iosapi.mm
+++ b/Engine/system/api/iosapi.mm
@@ -197,6 +197,10 @@ static void drawFrame();
     swapContext();
     }
   }
+
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)ex {
+  [self touchesEnded:touches withEvent:ex];
+  }
 @end
 
 static TempestWindow* mainWindow = nullptr;


### PR DESCRIPTION
UIKit may cancel an active touch when the app loses the foreground or a system gesture interrupts input. The iOS backend handles began, moved and ended touches, but currently ignores cancellation, leaving the touch registered and the corresponding mouse button pressed.

Forward `touchesCancelled` through the existing `touchesEnded` path so Tempest removes the touch ID and emits the matching mouse-up event.

Validation:
- Release builds pass for iPhoneOS arm64 and iPhone Simulator arm64 at iOS 15.0
- Clang static analysis reports no new issue
- on an iPhone 15 Pro Max, backgrounding OpenGothic while holding movement releases the input and subsequent touches continue to work