### PR TITLE
Fix iOS view controller initialization and ownership

### DIFF
--- a/Engine/system/api/iosapi.mm
+++ b/Engine/system/api/iosapi.mm
@@ -211,11 +211,14 @@ static TempestWindow* mainWindow = nullptr;
   }
 
 -(id)init {
-  fullScreen = true;
+  self = [super init];
+  if(self!=nil)
+    fullScreen = true;
   return self;
   }
 
 - (void)viewDidLoad {
+  [super viewDidLoad];
   self.extendedLayoutIncludesOpaqueBars = YES;
   //self.modalPresentationStyle = UIModalPresentationFullScreen;
   //[self setNeedsStatusBarAppearanceUpdate];
@@ -240,8 +243,8 @@ static TempestWindow* mainWindow = nullptr;
   return UIInterfaceOrientationMaskAll;
   }
 
--(bool)setAsFullscreen: (bool)fullScreen {
-  self->fullScreen = fullScreen;
+-(bool)setAsFullscreen: (bool)value {
+  self->fullScreen = value;
   [self setNeedsStatusBarAppearanceUpdate];
   return true;
   }
@@ -265,7 +268,9 @@ static bool isApplicationActive = false;
   CGRect frame = [ [ UIScreen mainScreen ] bounds ];
   TempestWindow  * window = [ [ TempestWindow alloc ] initWithFrame: frame];
   window.contentScaleFactor = [UIScreen mainScreen].scale;
-  window.rootViewController = [ViewController new];
+  ViewController* controller = [ViewController new];
+  window.rootViewController = controller;
+  [controller release];
   window.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   window.backgroundColor = [ UIColor blackColor ];
 

--- a/Engine/system/api/iosapi.mm
+++ b/Engine/system/api/iosapi.mm
@@ -269,7 +269,7 @@ static bool isApplicationActive = false;
   TempestWindow  * window = [ [ TempestWindow alloc ] initWithFrame: frame];
   window.contentScaleFactor = [UIScreen mainScreen].scale;
   ViewController* controller = [ViewController new];
-  window.rootViewController = controller;
+  [window setRootViewController:controller];
   [controller release];
   window.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   window.backgroundColor = [ UIColor blackColor ];


### PR DESCRIPTION
The iOS view controller initializer currently skips `[super init]`, and its `viewDidLoad` override does not call the superclass implementation. The app delegate also keeps the `+1` ownership returned by `[ViewController new]` after assigning it to the retaining `rootViewController` property.

Use the normal UIKit initialization chain, call `[super viewDidLoad]` and balance the temporary controller ownership after assignment. Rename the fullscreen setter argument to avoid shadowing the ivar.

Validation:
- Release builds pass for iPhoneOS arm64 and iPhone Simulator arm64 at iOS 15.0
- Clang static analysis is clean for the controller initialization and ownership path
- the integrated build starts, backgrounds and resumes successfully on an iPhone 15 Pro Max