### PR TITLE
Stop the iOS display link when destroying a window

### DIFF
--- a/Engine/system/api/iosapi.mm
+++ b/Engine/system/api/iosapi.mm
@@ -109,6 +109,10 @@ static void drawFrame();
           }
       return -1;
       }
+
+    void clear() {
+      touch.clear();
+      }
     };
   TouchState touch;
   }
@@ -198,6 +202,22 @@ static void drawFrame();
     }
   }
 @end
+
+static void discardPendingEvent(TempestWindow* window) {
+  switch(window->curentEvent) {
+    case Event::Resize:
+      window->event.size.~SizeEvent();
+      break;
+    case Event::MouseDown:
+    case Event::MouseMove:
+    case Event::MouseUp:
+      window->event.mouse.~MouseEvent();
+      break;
+    default:
+      break;
+    }
+  window->curentEvent = Event::NoEvent;
+  }
 
 static TempestWindow* mainWindow = nullptr;
 
@@ -398,6 +418,15 @@ SystemApi::Window *iOSApi::implCreateWindow(Tempest::Window *owner, SystemApi::S
   }
 
 void iOSApi::implDestroyWindow(SystemApi::Window *w) {
+  auto wx = reinterpret_cast<TempestWindow*>(w);
+  if(wx==nullptr)
+    return;
+  wx->owner = nullptr;
+  wx->hasPendingFrame.store(false);
+  [wx->displayLink invalidate];
+  wx->displayLink = nil;
+  discardPendingEvent(wx);
+  wx->touch.clear();
   }
 
 void iOSApi::implExit() {

--- a/Engine/system/api/iosapi.mm
+++ b/Engine/system/api/iosapi.mm
@@ -419,8 +419,6 @@ SystemApi::Window *iOSApi::implCreateWindow(Tempest::Window *owner, SystemApi::S
 
 void iOSApi::implDestroyWindow(SystemApi::Window *w) {
   auto wx = reinterpret_cast<TempestWindow*>(w);
-  if(wx==nullptr)
-    return;
   wx->owner = nullptr;
   wx->hasPendingFrame.store(false);
   [wx->displayLink invalidate];


### PR DESCRIPTION
`implDestroyWindow` is currently empty on iOS, so its display link can remain registered after the Tempest window owner is destroyed. Pending input or resize data and active touch IDs can also survive until a later window is created.

Clear the owner and pending-frame flag first, invalidate the display link, destroy the queued event payload and clear the tracked touches. The event cleanup covers every event type currently queued by this backend.

Validation:
- Release builds pass for iPhoneOS arm64 and iPhone Simulator arm64 at iOS 15.0
- Clang static analysis reports no new issue
- an integrated probe on an iPhone 15 Pro Max destroys the first window, creates a second one and renders it successfully