### PR TITLE
Fix cursor visibility for window cursor state

### DIFF
--- a/Engine/ui/widget.cpp
+++ b/Engine/ui/widget.cpp
@@ -463,7 +463,7 @@ void Widget::setFocus(bool b) {
 
 void Widget::setCursorShape(CursorShape cs) {
   wstate.cursor = cs;
-  if(wstate.moveOver) {
+  if(wstate.moveOver || dynamic_cast<Window*>(this)!=nullptr) {
     Widget* root=implTrieRoot(this);
     if(auto w = dynamic_cast<Window*>(root))
       w->implShowCursor(cs);


### PR DESCRIPTION
Fix for Linux on X11.
The mouse cursor always remained visible ingame. The initial `setCursorShape(CursorShape::Hidden)` call in _common/mainwindow.cpp_ either did not update the (system native) mouse cursor until a mouse moving event was triggered or it does not stick. 
The expected behaviour however is that the cursor is hidden while OpenGothic has focus and only become visible when losing focus, e.g. alt-tabbing scenario. So we have to touch the X11 API.

`Widget::setCursorShape() ` only updated the native window cursor when `wstate.moveOver` was set..During window initialisation, this state is not yet set. We have a timing problem leading to `setCursorShape(CursorShape::Hidden)` not reaching the X11 implementation part. Basically this caused that setting the cursor during  startup had no effect.


We fix this when we make `Window::setCursorShape()` update the cursor immediately when called, even when `moveOver` has not been set yet.

This hides the native window cursor during initialisation of the game and it consequently stays invisible when the game starts. 

Tested on Linux with X11:
Cursor is hidden immediately on startup of the game and remains hidden as long as OpenGothic has focus. Cursor becomes visible when losing focus, e.g. alt-tabbing. Cursor is hidden again when focus comes back to OpenGothic.
I did not witness any mouse movement or handling changes on the potato of a machine I am running this with.

