### PR TITLE
Fix X11 cursor visibility on window enter

### DIFF
--- a/Engine/system/api/x11api.cpp
+++ b/Engine/system/api/x11api.cpp
@@ -599,7 +599,7 @@ void X11Api::implProcessEvents(SystemApi::AppCallBack &cb) {
         break;
         }
       case EnterNotify: {
-        SystemApi::dispatchMouseReevaluate(cb,Point(xev.xcrossing.x,xev.xcrossing.y));
+        SystemApi::dispatchMouseEnter(cb,Point(xev.xcrossing.x,xev.xcrossing.y));
         break;
         }
       case MotionNotify: {

--- a/Engine/system/api/x11api.cpp
+++ b/Engine/system/api/x11api.cpp
@@ -279,7 +279,7 @@ SystemApi::Window *X11Api::implCreateWindow(Tempest::Window *owner, uint32_t w, 
 
   XSetWindowAttributes swa={};
   swa.colormap   = cmap;
-  swa.event_mask = PointerMotionMask | ExposureMask |
+  swa.event_mask = PointerMotionMask | EnterWindowMask | ExposureMask |
                    ButtonPressMask | ButtonReleaseMask |
                    KeyPressMask | KeyReleaseMask |
                    FocusChangeMask | StructureNotifyMask |
@@ -596,6 +596,10 @@ void X11Api::implProcessEvents(SystemApi::AppCallBack &cb) {
             SystemApi::dispatchMouseDown(cb, e); else
             SystemApi::dispatchMouseUp(cb, e);
           }
+        break;
+        }
+      case EnterNotify: {
+        SystemApi::dispatchMouseReevaluate(cb,Point(xev.xcrossing.x,xev.xcrossing.y));
         break;
         }
       case MotionNotify: {

--- a/Engine/system/eventdispatcher.cpp
+++ b/Engine/system/eventdispatcher.cpp
@@ -81,6 +81,8 @@ void EventDispatcher::dispatchMouseUp(Widget& /*wnd*/, MouseEvent &e) {
   }
 
 void EventDispatcher::dispatchMouseMove(Widget& wnd, MouseEvent &e) {
+  mouseWindow = &wnd;
+  mousePosition = e.pos();
   auto btn = Event::ButtonNone;
   for(uint8_t i=0; i<Event::ButtonLast; ++i)
     if(!mouseUp[i].expired()) {
@@ -137,6 +139,40 @@ void EventDispatcher::dispatchMouseMove(Widget& wnd, MouseEvent &e) {
   auto wptr = implDispatch(wnd,e1);
   implSetMouseOver(wptr,e1);
   }
+
+void EventDispatcher::dispatchMouseReevaluate(Widget& wnd) {
+  if(mouseWindow!=&wnd)
+    return;
+  dispatchMouseReevaluate(wnd,mousePosition);
+  }
+
+void EventDispatcher::dispatchMouseReevaluate(Widget& wnd, Point pos) {
+  mouseWindow = &wnd;
+  mousePosition = pos;
+  if(focusWindow!=&wnd)
+    return;
+  MouseEvent e(mousePosition.x,
+               mousePosition.y,
+               Event::ButtonNone,
+               Event::M_NoModifier,
+               0,
+               0,
+               Event::MouseMove);
+
+  for(auto i:overlays) {
+    if(!i->bind(wnd))
+      continue;
+    auto wptr = implDispatch(*i,e);
+    if(wptr!=nullptr) {
+      implSetMouseOver(wptr,e,true);
+      return;
+      }
+    }
+
+  auto wptr = implDispatch(wnd,e);
+  implSetMouseOver(wptr,e,true);
+  }
+
 
 void EventDispatcher::dispatchMouseWheel(Widget& wnd, MouseEvent &e) {
   if(e.delta==0)
@@ -216,13 +252,16 @@ void EventDispatcher::dispatchClose(Widget& wnd, CloseEvent& e) {
 
 void EventDispatcher::dispatchFocus(Widget& wnd, FocusEvent& e) {
   if(e.in) {
+    focusWindow = &wnd;
+
     if(auto f = focusLast.lock()) {
       f->widget->setFocus(true);
       }
     focusLast.reset();
+    dispatchMouseReevaluate(wnd);
     return;
     }
-
+  focusWindow = nullptr;
   if(!focusLast.expired())
     return;
 
@@ -414,14 +453,17 @@ std::shared_ptr<Widget::Ref> EventDispatcher::implDispatch(Widget &root, KeyEven
   return nullptr;
   }
 
-void EventDispatcher::implSetMouseOver(const std::shared_ptr<Widget::Ref> &wptr,MouseEvent& orig) {
+void EventDispatcher::implSetMouseOver(const std::shared_ptr<Widget::Ref> &wptr,MouseEvent& orig,bool force) {
   auto    widget = wptr==nullptr ? nullptr : wptr->widget;
   Widget* oldW   = nullptr;
   if(auto old = mouseOver.lock())
     oldW = old->widget;
 
-  if(widget==oldW)
+  if(widget==oldW) {
+    if(force)
+      implExcMouseOver(widget,oldW);
     return;
+    }
 
   implExcMouseOver(widget,oldW);
 

--- a/Engine/system/eventdispatcher.cpp
+++ b/Engine/system/eventdispatcher.cpp
@@ -81,8 +81,6 @@ void EventDispatcher::dispatchMouseUp(Widget& /*wnd*/, MouseEvent &e) {
   }
 
 void EventDispatcher::dispatchMouseMove(Widget& wnd, MouseEvent &e) {
-  mouseWindow = &wnd;
-  mousePosition = e.pos();
   auto btn = Event::ButtonNone;
   for(uint8_t i=0; i<Event::ButtonLast; ++i)
     if(!mouseUp[i].expired()) {
@@ -140,19 +138,13 @@ void EventDispatcher::dispatchMouseMove(Widget& wnd, MouseEvent &e) {
   implSetMouseOver(wptr,e1);
   }
 
-void EventDispatcher::dispatchMouseReevaluate(Widget& wnd) {
-  if(mouseWindow!=&wnd)
-    return;
-  dispatchMouseReevaluate(wnd,mousePosition);
-  }
-
-void EventDispatcher::dispatchMouseReevaluate(Widget& wnd, Point pos) {
-  mouseWindow = &wnd;
-  mousePosition = pos;
-  if(focusWindow!=&wnd)
-    return;
-  MouseEvent e(mousePosition.x,
-               mousePosition.y,
+// Triggered on X11 EnterNotify. Unlike dispatchMouseMove, no MotionNotify is guaranteed
+// to follow (e.g. window shown/refocused under an already idle pointer), so the
+// hovered widget and its cursor shape would stay stale until next actual mouse
+// move. Synthesize one MouseMove at reported enter position forcing a widget test.
+void EventDispatcher::dispatchMouseEnter(Widget& wnd, Point pos) {
+  MouseEvent e(pos.x,
+               pos.y,
                Event::ButtonNone,
                Event::M_NoModifier,
                0,
@@ -164,6 +156,9 @@ void EventDispatcher::dispatchMouseReevaluate(Widget& wnd, Point pos) {
       continue;
     auto wptr = implDispatch(*i,e);
     if(wptr!=nullptr) {
+      // force=true: The native cursor may have gone stale while pointer was
+      // outside of the window, even if the hit tested widget is the same as
+      // before. Identity of widget is insufficient  to skip reapplication of it.
       implSetMouseOver(wptr,e,true);
       return;
       }
@@ -172,7 +167,6 @@ void EventDispatcher::dispatchMouseReevaluate(Widget& wnd, Point pos) {
   auto wptr = implDispatch(wnd,e);
   implSetMouseOver(wptr,e,true);
   }
-
 
 void EventDispatcher::dispatchMouseWheel(Widget& wnd, MouseEvent &e) {
   if(e.delta==0)
@@ -252,16 +246,13 @@ void EventDispatcher::dispatchClose(Widget& wnd, CloseEvent& e) {
 
 void EventDispatcher::dispatchFocus(Widget& wnd, FocusEvent& e) {
   if(e.in) {
-    focusWindow = &wnd;
-
     if(auto f = focusLast.lock()) {
       f->widget->setFocus(true);
       }
     focusLast.reset();
-    dispatchMouseReevaluate(wnd);
     return;
     }
-  focusWindow = nullptr;
+
   if(!focusLast.expired())
     return;
 

--- a/Engine/system/eventdispatcher.h
+++ b/Engine/system/eventdispatcher.h
@@ -15,6 +15,8 @@ class EventDispatcher final {
     void dispatchMouseDown (Widget& wnd, Tempest::MouseEvent& event);
     void dispatchMouseUp   (Widget& wnd, Tempest::MouseEvent& event);
     void dispatchMouseMove (Widget& wnd, Tempest::MouseEvent& event);
+    void dispatchMouseReevaluate(Widget& wnd);
+    void dispatchMouseReevaluate(Widget& wnd, Point pos);
     void dispatchMouseWheel(Widget& wnd, Tempest::MouseEvent& event);
 
     void dispatchKeyDown   (Widget& wnd, Tempest::KeyEvent&   event, uint32_t scancode);
@@ -39,7 +41,7 @@ class EventDispatcher final {
 
     bool                         implShortcut(Tempest::Widget &w, Tempest::KeyEvent& event);
     std::shared_ptr<Widget::Ref> implDispatch(Tempest::Widget &w, Tempest::KeyEvent&   event);
-    void                         implSetMouseOver(const std::shared_ptr<Widget::Ref>& s, MouseEvent& orig);
+    void                         implSetMouseOver(const std::shared_ptr<Widget::Ref> &wptr,MouseEvent& orig,bool force=false);
     void                         implExcMouseOver(Widget *w, Widget *old);
     void                         handleModKey(const KeyEvent& e);
 
@@ -49,6 +51,9 @@ class EventDispatcher final {
     std::weak_ptr<Widget::Ref>   mouseUp[Event::MouseButton::ButtonLast];
     std::weak_ptr<Widget::Ref>   mouseLast;
     std::weak_ptr<Widget::Ref>   mouseOver;
+    Widget*                      mouseWindow = nullptr;
+    Widget*                      focusWindow = nullptr;
+    Point                        mousePosition;
 
     std::weak_ptr<Widget::Ref>   focusLast;
 

--- a/Engine/system/eventdispatcher.h
+++ b/Engine/system/eventdispatcher.h
@@ -15,8 +15,7 @@ class EventDispatcher final {
     void dispatchMouseDown (Widget& wnd, Tempest::MouseEvent& event);
     void dispatchMouseUp   (Widget& wnd, Tempest::MouseEvent& event);
     void dispatchMouseMove (Widget& wnd, Tempest::MouseEvent& event);
-    void dispatchMouseReevaluate(Widget& wnd);
-    void dispatchMouseReevaluate(Widget& wnd, Point pos);
+    void dispatchMouseEnter(Widget& wnd, Point pos);
     void dispatchMouseWheel(Widget& wnd, Tempest::MouseEvent& event);
 
     void dispatchKeyDown   (Widget& wnd, Tempest::KeyEvent&   event, uint32_t scancode);
@@ -51,9 +50,6 @@ class EventDispatcher final {
     std::weak_ptr<Widget::Ref>   mouseUp[Event::MouseButton::ButtonLast];
     std::weak_ptr<Widget::Ref>   mouseLast;
     std::weak_ptr<Widget::Ref>   mouseOver;
-    Widget*                      mouseWindow = nullptr;
-    Widget*                      focusWindow = nullptr;
-    Point                        mousePosition;
 
     std::weak_ptr<Widget::Ref>   focusLast;
 

--- a/Engine/system/systemapi.cpp
+++ b/Engine/system/systemapi.cpp
@@ -128,6 +128,14 @@ void SystemApi::dispatchMouseMove(Tempest::Window &cb, MouseEvent &e) {
   dispatcher.dispatchMouseMove(cb,e);
   }
 
+void SystemApi::dispatchMouseReevaluate(Tempest::Widget &cb) {
+  dispatcher.dispatchMouseReevaluate(cb);
+  }
+
+void SystemApi::dispatchMouseReevaluate(Tempest::Widget &cb, Point pos) {
+  dispatcher.dispatchMouseReevaluate(cb,pos);
+  }
+
 void SystemApi::dispatchMouseWheel(Tempest::Window &cb, MouseEvent &e) {
   dispatcher.dispatchMouseWheel(cb,e);
   }

--- a/Engine/system/systemapi.cpp
+++ b/Engine/system/systemapi.cpp
@@ -128,12 +128,8 @@ void SystemApi::dispatchMouseMove(Tempest::Window &cb, MouseEvent &e) {
   dispatcher.dispatchMouseMove(cb,e);
   }
 
-void SystemApi::dispatchMouseReevaluate(Tempest::Widget &cb) {
-  dispatcher.dispatchMouseReevaluate(cb);
-  }
-
-void SystemApi::dispatchMouseReevaluate(Tempest::Widget &cb, Point pos) {
-  dispatcher.dispatchMouseReevaluate(cb,pos);
+void SystemApi::dispatchMouseEnter(Tempest::Widget &cb, Point pos) {
+  dispatcher.dispatchMouseEnter(cb,pos);
   }
 
 void SystemApi::dispatchMouseWheel(Tempest::Window &cb, MouseEvent &e) {

--- a/Engine/system/systemapi.h
+++ b/Engine/system/systemapi.h
@@ -95,6 +95,8 @@ class SystemApi {
     static void      dispatchMouseDown (Tempest::Window& cb, MouseEvent& e);
     static void      dispatchMouseUp   (Tempest::Window& cb, MouseEvent& e);
     static void      dispatchMouseMove (Tempest::Window& cb, MouseEvent& e);
+    static void      dispatchMouseReevaluate(Tempest::Widget& cb);
+    static void      dispatchMouseReevaluate(Tempest::Widget& cb, Point pos);
     static void      dispatchMouseWheel(Tempest::Window& cb, MouseEvent& e);
 
     static void      dispatchKeyDown   (Tempest::Window& cb, KeyEvent& e, uint32_t scancode);
@@ -117,6 +119,7 @@ class SystemApi {
 
   friend class Tempest::Window;
   friend class Tempest::Application;
+  friend class Tempest::Widget;
   };
 
 }

--- a/Engine/system/systemapi.h
+++ b/Engine/system/systemapi.h
@@ -95,8 +95,7 @@ class SystemApi {
     static void      dispatchMouseDown (Tempest::Window& cb, MouseEvent& e);
     static void      dispatchMouseUp   (Tempest::Window& cb, MouseEvent& e);
     static void      dispatchMouseMove (Tempest::Window& cb, MouseEvent& e);
-    static void      dispatchMouseReevaluate(Tempest::Widget& cb);
-    static void      dispatchMouseReevaluate(Tempest::Widget& cb, Point pos);
+    static void      dispatchMouseEnter(Tempest::Widget& cb, Point pos);
     static void      dispatchMouseWheel(Tempest::Window& cb, MouseEvent& e);
 
     static void      dispatchKeyDown   (Tempest::Window& cb, KeyEvent& e, uint32_t scancode);
@@ -119,7 +118,6 @@ class SystemApi {
 
   friend class Tempest::Window;
   friend class Tempest::Application;
-  friend class Tempest::Widget;
   };
 
 }

--- a/Engine/ui/widget.cpp
+++ b/Engine/ui/widget.cpp
@@ -2,6 +2,7 @@
 
 #include <Tempest/Layout>
 #include <Tempest/Application>
+#include <Tempest/SystemApi>
 #include <Tempest/UiOverlay>
 #include <Tempest/Window>
 
@@ -227,6 +228,7 @@ Widget& Widget::implAddWidget(Widget *w,size_t at) {
   if(astate.disable>0)
     implDisableSum(w,astate.disable);
   lay->applyLayout();
+  SystemApi::dispatchMouseReevaluate(*implTrieRoot(this));
   update();
   return *w;
   }
@@ -296,6 +298,7 @@ void Widget::setGeometry(const Rect &rect) {
     SizeEvent e(uint32_t(rect.w),uint32_t(rect.h));
     resizeEvent( e );
     }
+  SystemApi::dispatchMouseReevaluate(*implTrieRoot(this));
   }
 
 void Widget::setGeometry(int x, int y, int w, int h) {
@@ -451,6 +454,7 @@ void Widget::setVisible(bool v) {
     w->update();
     w->applyLayout();
     }
+  SystemApi::dispatchMouseReevaluate(*implTrieRoot(this));
   }
 
 bool Widget::isVisible() const {

--- a/Engine/ui/widget.cpp
+++ b/Engine/ui/widget.cpp
@@ -2,7 +2,6 @@
 
 #include <Tempest/Layout>
 #include <Tempest/Application>
-#include <Tempest/SystemApi>
 #include <Tempest/UiOverlay>
 #include <Tempest/Window>
 
@@ -228,7 +227,6 @@ Widget& Widget::implAddWidget(Widget *w,size_t at) {
   if(astate.disable>0)
     implDisableSum(w,astate.disable);
   lay->applyLayout();
-  SystemApi::dispatchMouseReevaluate(*implTrieRoot(this));
   update();
   return *w;
   }
@@ -298,7 +296,6 @@ void Widget::setGeometry(const Rect &rect) {
     SizeEvent e(uint32_t(rect.w),uint32_t(rect.h));
     resizeEvent( e );
     }
-  SystemApi::dispatchMouseReevaluate(*implTrieRoot(this));
   }
 
 void Widget::setGeometry(int x, int y, int w, int h) {
@@ -454,7 +451,6 @@ void Widget::setVisible(bool v) {
     w->update();
     w->applyLayout();
     }
-  SystemApi::dispatchMouseReevaluate(*implTrieRoot(this));
   }
 
 bool Widget::isVisible() const {


### PR DESCRIPTION


Fix for Linux on X11.
The native mouse cursor remained visible in-game even though `CursorShape::Hidden` was requested during game startup.

The initial PR https://github.com/Try/Tempest/pull/98/changes is flawed. It adressed  the symptom but violated the framework cursor management model completely. 

> 
> Hi, @Abendlied and thanks for PR!
> 
> Unfortunately, in current state this is not a working code. In engine, it's allowed to call setCursorShape at any point. For example have LineEdit under the mouse and call setCursorShape on the parent window - this swap cursor incorrectly. There can be multiple windows at once, and so on.
> 
> In principle, one way to actually fix this is to reevaluate EventDispatcher::mouseOver, if widget is created or widget's geometry is changed.

Now in the new approach I try to follow the recommendation.

`EventDispatcher` did not know the mouse position until after receiving a `MotionNotify`. When the mouse was already over the game window, and no mouse movement received, the cursor state was not updated. This happened every time due to fullscreen.

The new implementation now gets the initial pointer position from `EnterNotify` and reevaluates the hovered widget when the window receives focus. The hover state is also reevaluated with widget geometry change.
`Window::setCursorShape()` stays how it is, cursor management is now in `EventDispatcher`.


Tested on Linux with X11:
Cursor is hidden immediately on startup of the game and remains hidden as long as OpenGothic has focus. Cursor becomes visible when losing focus, e.g. alt-tabbing. Cursor is hidden again when focus comes back to OpenGothic for hovering.