### PR TITLE
Defer iOS display-link context switching

### DIFF
--- a/Engine/system/api/iosapi.mm
+++ b/Engine/system/api/iosapi.mm
@@ -135,10 +135,16 @@ static void drawFrame();
   swapContext();
   }
 
-- (void)drawFrame {
+- (void)displayLinkDidFire:(CADisplayLink*)sender {
   hasPendingFrame.store(true);
-  swapContext();
-  // drawFrame();
+
+  TempestWindow* const window = self;
+  // Let UIKit unwind the display-link callback before resuming the engine.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if(window->owner==nullptr || window->displayLink!=sender)
+      return;
+    swapContext();
+    });
   }
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)ex {
@@ -406,7 +412,7 @@ static SystemApi::Window* createWindow(Tempest::Window *owner, uint32_t w, uint3
   auto window = mainWindow;
   
   window->owner = owner;
-  window->displayLink = [CADisplayLink displayLinkWithTarget:window selector:@selector(drawFrame)];
+  window->displayLink = [CADisplayLink displayLinkWithTarget:window selector:@selector(displayLinkDidFire:)];
   //by adding the display link to the run loop our draw method will be called 60 times per second
   [window->displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
   window->hasPendingFrame.store(true);


### PR DESCRIPTION
## Summary
- mark frames pending in the CADisplayLink callback without switching contexts there
- defer the engine resume to the main queue so UIKit can unwind the callback first
- use the CADisplayLink sender signature and ignore queued work for a destroyed or replaced display link

## Validation
- iOS Simulator Release build, arm64, deployment target 15.0
- iPhoneOS Release build, arm64, deployment target 15.0
- iosapi.mm syntax check with warnings treated as errors
- full TempestTests suite on macOS
- 5/5 simulator runs completed 60 consecutive display-link-driven frames

I also repeated the nested processEvents reproducer used for #94. This change alone still reaches the existing invalid-autorelease-pool failure after the nested call returns. With #94 applied on top, the same 60-frame reproducer passes 5/5 runs. The two changes therefore address separate issues.