### PR TITLE
Fix Vulkan sampler cleanup and allocation failure handling

### DIFF
--- a/Engine/gapi/vulkan/vsamplercache.cpp
+++ b/Engine/gapi/vulkan/vsamplercache.cpp
@@ -18,7 +18,7 @@ VSamplerCache::~VSamplerCache() {
   if(smpDefault!=VK_NULL_HANDLE)
     vkDestroySampler(device->device.impl,smpDefault,nullptr);
   for(auto& i:chunks)
-    vkDestroySampler(device->device.impl,i.sampler,nullptr);
+    vkDestroySampler(device->device.impl,VkSampler(i.value),nullptr);
   }
 
 VkSamplerCreateInfo VSamplerCache::createInfo(const VDevice& dev, const Sampler& s) {
@@ -84,6 +84,7 @@ uint64_t VSamplerCache::implGet(const Sampler& s) {
     }
   catch(...) {
     chunks.pop_back();
+    throw;
     }
   return b.value;
   }

--- a/Engine/gapi/vulkan/vsamplercache.h
+++ b/Engine/gapi/vulkan/vsamplercache.h
@@ -30,7 +30,6 @@ class VSamplerCache final {
   private:
     struct Entry {
       Sampler   smp;
-      VkSampler sampler = VK_NULL_HANDLE;
       uint64_t  value   = 0;
       };
 


### PR DESCRIPTION
- Destroy cached samplers using their stored handles, fixing a resource leak
- Rethrow allocation failures instead of accessing a removed cache entry

I've verified with Vulkan validation enabled and in the game.

Basically, cached sampler handles weren’t being destroyed properly, producing Vulkan validation errors at device shutdown.
If allocation failed, the code removed the cache entry but then accessed it through an invalid reference-undefined behavior.