### PR TITLE
Fix command-buffer list reuse and traversal

### DIFF
--- a/Engine/gapi/directx12/dxcommandbuffer.cpp
+++ b/Engine/gapi/directx12/dxcommandbuffer.cpp
@@ -267,7 +267,7 @@ DxCommandBuffer::~DxCommandBuffer() {
   for(size_t i=0; i<chunks.size(); ++i) {
     auto cmd = node->val[i%chunks.chunkSize].impl;
     dxAssert(cmd->Release());
-    if(i+1==chunks.chunkSize)
+    if((i+1)%chunks.chunkSize==0)
       node = node->next;
     }
   }
@@ -314,7 +314,7 @@ void DxCommandBuffer::reset() {
     auto cmd = node->val[i%chunks.chunkSize].impl;
     cmd->Release();
     // dxAssert(cmd->Reset(pool.get(),nullptr));
-    if(i+1==chunks.chunkSize)
+    if((i+1)%chunks.chunkSize==0)
       node = node->next;
     }
   chunks.clear();

--- a/Engine/gapi/directx12/dxdevice.cpp
+++ b/Engine/gapi/directx12/dxdevice.cpp
@@ -433,7 +433,7 @@ std::shared_ptr<DxFence> DxDevice::submit(DxCommandBuffer& cmd) {
   auto node = cmd.chunks.begin();
   for(size_t i=0; i<size; ++i) {
     flat[i] = node->val[i%cmd.chunks.chunkSize].impl;
-    if(i+1==cmd.chunks.chunkSize)
+    if((i+1)%cmd.chunks.chunkSize==0)
       node = node->next;
     }
 

--- a/Engine/gapi/vulkan/vcommandbuffer.cpp
+++ b/Engine/gapi/vulkan/vcommandbuffer.cpp
@@ -175,7 +175,7 @@ VCommandBuffer::~VCommandBuffer() {
   auto node = chunks.begin();
   for(size_t i=0; i<chunks.size(); ++i) {
     flat[i] = node->val[i%chunks.chunkSize].impl;
-    if(i+1==chunks.chunkSize)
+    if((i+1)%chunks.chunkSize==0)
       node = node->next;
     }
   vkFreeCommandBuffers(device.device.impl,pool.impl,uint32_t(chunks.size()),flat.get());
@@ -193,7 +193,7 @@ void VCommandBuffer::reset() {
   for(size_t i=1; i<chunks.size(); ++i) {
     auto cmd = node->val[i%chunks.chunkSize].impl;
     vkFreeCommandBuffers(device.device.impl,pool.impl,1,&cmd);
-    if(i+1==chunks.chunkSize)
+    if((i+1)%chunks.chunkSize==0)
       node = node->next;
     }
   chunks.clear();
@@ -246,7 +246,7 @@ void VCommandBuffer::end() {
   for(size_t i=0; i<chunks.size(); ++i) {
     auto cmd = node->val[i%chunks.chunkSize].impl;
     vkAssert(vkEndCommandBuffer(cmd));
-    if(i+1==chunks.chunkSize)
+    if((i+1)%chunks.chunkSize==0)
       node = node->next;
     }
   }

--- a/Engine/gapi/vulkan/vdevice.cpp
+++ b/Engine/gapi/vulkan/vdevice.cpp
@@ -1147,7 +1147,7 @@ std::shared_ptr<VFence> VDevice::submit(VCommandBuffer& cmd) {
       flat[i].pNext         = nullptr;
       flat[i].commandBuffer = node->val[i%cmd.chunks.chunkSize].impl;
       flat[i].deviceMask    = 0;
-      if(i+1==cmd.chunks.chunkSize)
+      if((i+1)%cmd.chunks.chunkSize==0)
         node = node->next;
       }
 
@@ -1170,7 +1170,7 @@ std::shared_ptr<VFence> VDevice::submit(VCommandBuffer& cmd) {
     auto node = cmd.chunks.begin();
     for(size_t i=0; i<cmd.chunks.size(); ++i) {
       flat[i] = node->val[i%cmd.chunks.chunkSize].impl;
-      if(i+1==cmd.chunks.chunkSize)
+      if((i+1)%cmd.chunks.chunkSize==0)
         node = node->next;
       }
     VkSubmitInfo submitInfo = {};

--- a/Engine/utility/smallarray.h
+++ b/Engine/utility/smallarray.h
@@ -56,6 +56,8 @@ namespace Detail {
           delete n;
           n = nx;
           }
+        root.next = nullptr;
+        back = &root;
         backSz = 0;
         allSz  = 0;
         }


### PR DESCRIPTION
Fixes dangling pointers after clearing command-buffer lists and incorrect traversal beyond 64 entries.

Reproduction:
- Add 33 entries to SmallList<T, 32>, call clear(), then push another entry. AddressSanitizer reports a heap-use-after-free.
- Traverse 65 entries using the existing command-buffer loops. Entry 65 repeats entry 33 instead of advancing to the third node.

Verified with sanitizers and Vulkan/DirectX 12 regression checks covering up to 97 render passes, buffer reuse and destruction.