### PR TITLE
Respect host iOS orientation policy

### DIFF
--- a/Engine/system/api/iosapi.mm
+++ b/Engine/system/api/iosapi.mm
@@ -386,11 +386,6 @@ static void deactivateWindow(TempestWindow* window) {
   return configuration;
   }
 
-- (UIInterfaceOrientationMask)application:(UIApplication *)application
-  supportedInterfaceOrientationsForWindow:(UIWindow *)window {
-  return UIInterfaceOrientationMaskAll;
-  }
-
 - (void)applicationWillTerminate:(UIApplication *)application {
   (void)application;
   }


### PR DESCRIPTION
Remove the app delegate override that always returns `UIInterfaceOrientationMaskAll`, so UIKit respects the app's `Info.plist`. The view controller still supports all orientations.

Tested on iOS 18 and 27 simulators: master rotates a landscape-only app to portrait; this change keeps it landscape. macOS tests and iPhoneOS/Simulator Release builds pass.
